### PR TITLE
[UI/Compose] SearchMovieScreen 개선

### DIFF
--- a/app/src/main/java/com/jg/moviesearch/ui/screen/SearchMovieScreen.kt
+++ b/app/src/main/java/com/jg/moviesearch/ui/screen/SearchMovieScreen.kt
@@ -41,7 +41,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.flowWithLifecycle
 import coil.compose.AsyncImage
 import com.jg.moviesearch.core.model.domain.MovieWithPoster
 import com.jg.moviesearch.ui.model.MovieUiEffect
@@ -50,6 +53,8 @@ import com.jg.moviesearch.ui.viewmodel.MovieDisplayItem
 import com.jg.moviesearch.ui.viewmodel.MovieViewModel
 import com.jg.moviesearch.ui.viewmodel.MovieDisplayType
 import com.jg.moviesearch.ui.viewmodel.MovieUiState
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.distinctUntilChanged
 
 @Composable
 fun SearchMovieRoute(
@@ -61,28 +66,35 @@ fun SearchMovieRoute(
     val searchQuery by viewModel.searchQuery.collectAsStateWithLifecycle()
     val listState = rememberLazyListState()
 
+    val lifecycleOwner = LocalLifecycleOwner.current
+
     val snackbarHostState = remember { SnackbarHostState() }
 
-    LaunchedEffect(viewModel.uiEffect) {
-        viewModel.uiEffect.collect { effect ->
-            when (effect) {
-                is MovieUiEffect.ShowError -> {
-                    snackbarHostState.showSnackbar(
-                        message = effect.message,
-                        duration = SnackbarDuration.Short
-                    )
-                }
+    LaunchedEffect(Unit) {
+        viewModel.uiEffect
+            .flowWithLifecycle(lifecycleOwner.lifecycle, Lifecycle.State.STARTED)
+            .collect { effect ->
+                when (effect) {
+                    is MovieUiEffect.ShowError -> {
+                        snackbarHostState.showSnackbar(
+                            message = effect.message,
+                            duration = SnackbarDuration.Short
+                        )
+                    }
 
-                is MovieUiEffect.NavigateToDetail -> {
-                    onMovieClickWithList(effect.movieList, effect.position)
+                    is MovieUiEffect.NavigateToDetail -> {
+                        onMovieClickWithList(effect.movieList, effect.position)
+                    }
                 }
-            }
         }
     }
 
     // 무한 스크롤 감지
-    LaunchedEffect(listState) {
+    LaunchedEffect(uiState.hasMoreData, uiState.isLoadingMore) {
+        if (!uiState.hasMoreData || uiState.isLoadingMore)
+            return@LaunchedEffect
         snapshotFlow { listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index }
+            .distinctUntilChanged()
             .collect { lastVisibleItemIndex ->
                 if (lastVisibleItemIndex != null) {
                     if (viewModel.shouldLoadMore(lastVisibleItemIndex)) {

--- a/app/src/main/java/com/jg/moviesearch/ui/screen/SearchMovieScreen.kt
+++ b/app/src/main/java/com/jg/moviesearch/ui/screen/SearchMovieScreen.kt
@@ -63,7 +63,6 @@ fun SearchMovieRoute(
     viewModel: MovieViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
-    val searchQuery by viewModel.searchQuery.collectAsStateWithLifecycle()
     val listState = rememberLazyListState()
 
     val lifecycleOwner = LocalLifecycleOwner.current
@@ -107,7 +106,7 @@ fun SearchMovieRoute(
     SearchMovieScreen(
         modifier = modifier,
         uiState = uiState,
-        searchQuery = searchQuery,
+        searchQuery = uiState.searchQuery,
         listState = listState,
         snackbarHostState = snackbarHostState,
         onAction = { action ->

--- a/app/src/main/java/com/jg/moviesearch/ui/viewmodel/MovieViewModel.kt
+++ b/app/src/main/java/com/jg/moviesearch/ui/viewmodel/MovieViewModel.kt
@@ -1,5 +1,6 @@
 package com.jg.moviesearch.ui.viewmodel
 
+import androidx.compose.runtime.snapshotFlow
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.jg.moviesearch.core.domain.repository.MovieRepository
@@ -19,6 +20,8 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -31,15 +34,9 @@ class MovieViewModel @Inject constructor(
     private val _uiState = MutableStateFlow(MovieUiState())
     val uiState: StateFlow<MovieUiState> = _uiState.asStateFlow()
 
-    // 실시간 검색을 위한 검색어
-    private val _searchQuery = MutableStateFlow("")
-    val searchQuery: StateFlow<String> = _searchQuery.asStateFlow()
 
     private val _uiEffect = MutableSharedFlow<MovieUiEffect>()
     val uiEffect: SharedFlow<MovieUiEffect> = _uiEffect.asSharedFlow()
-
-    // 현재 검색 쿼리
-    private var currentSearchQuery: String = ""
 
     // ==================== 초기화 ====================
     init {
@@ -52,11 +49,12 @@ class MovieViewModel @Inject constructor(
     // 실시간 검색 설정
     @OptIn(ExperimentalCoroutinesApi::class)
     private fun setupRealTimeSearch() {
-        _searchQuery
+        _uiState
+            .map { it.searchQuery }
+            .distinctUntilChanged()
             .debounce(300)
             .filter { it.trim().isNotEmpty() }
             .onEach { query ->
-                currentSearchQuery = query.trim()
                 resetSearchState()
                 showLoading()
             }
@@ -70,22 +68,29 @@ class MovieViewModel @Inject constructor(
                         )
                     }
             }
-            .onEach {
-                if (it.isEmpty()) {
-                    handleSearchEmpty()
-                } else {
-                    handleSearchSuccess(movies = it)
+            .onEach { movie ->
+                runCatching {
+                    if (movie.isEmpty()) {
+                        handleSearchEmpty()
+                    } else {
+                        handleSearchSuccess(movies = movie)
+                    }
+                }.onFailure {
+                    handleError(
+                        message = it.message ?: "Unknown error",
+                        prefix = "영화 검색 실패"
+                    )
                 }
-            }
-            .launchIn(viewModelScope)
+            }.launchIn(viewModelScope)
     }
 
     // 검색어 업데이트
     fun updateSearchQuery(query: String) {
-        _searchQuery.value = query
-        if (query.trim().length >= 2) {
-            showLoading()
-        } else if (query.trim().isEmpty()) {
+        _uiState.update {
+            it.copy(searchQuery = query)
+        }
+
+        if (query.trim().isEmpty()) {
             clearSearchResults()
         }
     }
@@ -105,7 +110,7 @@ class MovieViewModel @Inject constructor(
     fun loadMoreMovies() {
         val currentState = _uiState.value
 
-        if (currentState.isLoadingMore || !currentState.hasMoreData || currentSearchQuery.isEmpty()) {
+        if (currentState.isLoadingMore || !currentState.hasMoreData || currentState.searchQuery.isEmpty()) {
             return
         }
 
@@ -113,7 +118,7 @@ class MovieViewModel @Inject constructor(
             state.copy(isLoadingMore = true)
         }
 
-        movieRepository.searchMoviesWithPoster(currentSearchQuery, currentState.currentPage + 1)
+        movieRepository.searchMoviesWithPoster(currentState.searchQuery, currentState.currentPage + 1)
             .catch { e ->
                 handleError(
                     message = e.message ?: "Unknown error",
@@ -293,6 +298,7 @@ class MovieViewModel @Inject constructor(
 }
 
 data class MovieUiState(
+    val searchQuery: String = "",
     val movies: List<MovieWithPoster> = emptyList(),
     val processedMovies: List<MovieDisplayItem> = emptyList(), // 추가
     val isLoading: Boolean = false,

--- a/app/src/main/java/com/jg/moviesearch/ui/viewmodel/MovieViewModel.kt
+++ b/app/src/main/java/com/jg/moviesearch/ui/viewmodel/MovieViewModel.kt
@@ -66,20 +66,14 @@ class MovieViewModel @Inject constructor(
                             message = it.message ?: "Unknown error",
                             prefix = "영화 검색 실패"
                         )
+                        emit(emptyList())
                     }
             }
             .onEach { movie ->
-                runCatching {
-                    if (movie.isEmpty()) {
-                        handleSearchEmpty()
-                    } else {
-                        handleSearchSuccess(movies = movie)
-                    }
-                }.onFailure {
-                    handleError(
-                        message = it.message ?: "Unknown error",
-                        prefix = "영화 검색 실패"
-                    )
+                if (movie.isEmpty()) {
+                    handleSearchEmpty()
+                } else {
+                    handleSearchSuccess(movies = movie)
                 }
             }.launchIn(viewModelScope)
     }


### PR DESCRIPTION
- LaunchedEffect가 중복 재실행되거나, 동일한 Flow를 여러 번 구독하면서 생기는 문제 개선
1. uiEffect 생명주기 추가하여 Started 일때 이벤트 처리하도록 수정
2. LaunchedEffect (viewModel.uiEffect) -> LaunchedEffect(Unit) 변경
3. 무한스크롤 LaunchedEffect Key , 조건 변경